### PR TITLE
[feat] 전체 페이지 다크모드 지원 및 스타일 적용

### DIFF
--- a/MOA-frontend/src/App.vue
+++ b/MOA-frontend/src/App.vue
@@ -1,6 +1,5 @@
 <template>
   <div :class="{ 'dark-mode': isDarkMode }" class="app-wrapper">
-  <div :class="{ 'dark-mode': isDarkMode }" class="app-wrapper">
     <Header v-if="!noHeader" />
     <div class="layout">
       <SideBar v-if="!noSideBar" />
@@ -24,15 +23,12 @@ import LoginPage from './pages/LoginPage.vue'
 import HomePage from './pages/HomePage.vue'
 import ResetPasswordPage from './pages/ResetPasswordPage.vue'
 import { useMoaStore } from '@/stores/moaStore'
-import { useMoaStore } from '@/stores/moaStore'
 
 const route = useRoute()
-const store = useMoaStore()
 const store = useMoaStore()
 const isModalOpen = ref(false)
 const noHeader = computed(() => route.meta.noHeader)
 const noSideBar = computed(() => route.meta.noSideBar)
-const isDarkMode = computed(() => store.isDarkMode)
 const isDarkMode = computed(() => store.isDarkMode)
 const toggleModal = () => {
   isModalOpen.value = !isModalOpen.value
@@ -89,4 +85,20 @@ onMounted(() => {
   color: #eee;
 }
 
+.dark-mode .bg-light {
+  background-color: #2b2b2b !important;
+}
+.dark-mode .text-dark {
+  color: #eee !important;
+}
+.dark-mode .form-control {
+  background-color: #3a3a3a;
+  color: #eee;
+  border-color: #555;
+}
+.dark-mode .card {
+  background-color: #2a2a2a;
+  color: #f0f0f0;
+  border: 1px solid #444;
+}
 </style>

--- a/MOA-frontend/src/App.vue
+++ b/MOA-frontend/src/App.vue
@@ -1,5 +1,6 @@
 <template>
   <div :class="{ 'dark-mode': isDarkMode }" class="app-wrapper">
+  <div :class="{ 'dark-mode': isDarkMode }" class="app-wrapper">
     <Header v-if="!noHeader" />
     <div class="layout">
       <SideBar v-if="!noSideBar" />
@@ -23,12 +24,15 @@ import LoginPage from './pages/LoginPage.vue'
 import HomePage from './pages/HomePage.vue'
 import ResetPasswordPage from './pages/ResetPasswordPage.vue'
 import { useMoaStore } from '@/stores/moaStore'
+import { useMoaStore } from '@/stores/moaStore'
 
 const route = useRoute()
+const store = useMoaStore()
 const store = useMoaStore()
 const isModalOpen = ref(false)
 const noHeader = computed(() => route.meta.noHeader)
 const noSideBar = computed(() => route.meta.noSideBar)
+const isDarkMode = computed(() => store.isDarkMode)
 const isDarkMode = computed(() => store.isDarkMode)
 const toggleModal = () => {
   isModalOpen.value = !isModalOpen.value
@@ -79,4 +83,10 @@ onMounted(() => {
   color: #f0f0f0;
   border: 1px solid #444;
 }
+.app-wrapper.dark-mode {
+  /* 다크모드 */
+  background: #222;
+  color: #eee;
+}
+
 </style>

--- a/MOA-frontend/src/stores/moaStore.js
+++ b/MOA-frontend/src/stores/moaStore.js
@@ -14,6 +14,7 @@ export const useMoaStore = defineStore('moa', () => {
 
   const user = ref(null)
   const isDarkMode = ref(false)
+  const isDarkMode = ref(false)
 
   const ENTRIES_URL = '/api/entries'
   const LEDGERS_URL = '/api/ledgers'
@@ -43,7 +44,7 @@ export const useMoaStore = defineStore('moa', () => {
       console.log('에러 발생:', error)
     }
   }
-  
+
   /**
    * 4) Ledgers / Users / UserLedgers 가져오기 (확장 예시)
    *    - 필요하다면 각 컬렉션도 불러와서 사용 가능합니다.

--- a/MOA-frontend/src/stores/moaStore.js
+++ b/MOA-frontend/src/stores/moaStore.js
@@ -14,7 +14,6 @@ export const useMoaStore = defineStore('moa', () => {
 
   const user = ref(null)
   const isDarkMode = ref(false)
-  const isDarkMode = ref(false)
 
   const ENTRIES_URL = '/api/entries'
   const LEDGERS_URL = '/api/ledgers'


### PR DESCRIPTION
전체 페이지 다크모드 지원 및 스타일 적용

🎯 목적
- 사용자에게 눈에 부담 없는 어두운 테마를 선택적으로 제공하기 위함
- Header, SideBar, 주요 페이지(Signup, ResetPassword, Profile 등)에 다크모드 대응 추가

📌 주요 작업
- Pinia store에 isDarkMode 상태 추가 및 전역 관리 로직 구현
- 각 페이지에서 darkMode 상태를 참조하여 <div :class="{ 'dark-mode': isDarkMode }"> 형태로 바인딩
- 다크모드일 때 적용될 클래스(.dark-mode)에 배경, 텍스트, 경계 색상 스타일 일괄 적용
- Signup, ResetPassword 페이지 등에서 다크모드일 경우 다른 이미지(signup-dark.png, resetpw-dark.png) 자동 적용
- Header.vue, SideBar.vue에서 .text-dark 같은 기본 Bootstrap 클래스 덮어쓰기(.dark-mode .text-dark 등)로 색상 문제 해결
- BaseInput, BaseButton 등 공통 컴포넌트도 다크모드에서 잘 보이도록 스타일 수정
- 차트(Chart.js) 옵션도 다크모드 시 폰트 컬러 등 맞춰 조정 가능하도록 옵션 분기 적용 예정

🐛 해결된 문제
- 텍스트 색상 충돌로 인한 글씨 미노출 문제 해결
- 다크모드 이미지 적용 시 경로 인식 오류 수정 (new URL + import.meta.url 사용)
- scoped 스타일 한계로 인한 오버라이드 문제 해결

💡 기타
- 컴포넌트 내 텍스트, 버튼, 입력창 등 UI 요소 전반에 대해 어두운 배경에 맞는 시각적 피드백 제공
- 향후 로컬스토리지 등에 다크모드 설정 저장 기능도 고려 가능
